### PR TITLE
feat: feature gate json, websocket and http; enable them by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
         with:
           command: clippy
           args: --no-default-features --features websocket --target wasm32-unknown-unknown -- -D warnings
+      
+      - name: Run clippy (with http feature)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features --features http --target wasm32-unknown-unknown -- -D warnings
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,24 @@ jobs:
         with:
           command: clippy
           args: --target wasm32-unknown-unknown -- -D warnings
+      
+      - name: Run clippy (no default features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features --target wasm32-unknown-unknown -- -D warnings
+
+      - name: Run clippy (with json feature)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features --features json --target wasm32-unknown-unknown -- -D warnings
+
+      - name: Run clippy (with websocket feature)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features --features websocket --target wasm32-unknown-unknown -- -D warnings
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,4 @@ pin-project = { version = "1.0", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ websocket = [
     'web-sys/BinaryType',
     "async-broadcast",
     "pin-project",
+    "futures-core",
+    "futures-sink",
 ]
 # Enables the HTTP API
 http = [
@@ -59,7 +61,8 @@ js-sys = "0.3"
 gloo-utils = "0.1.0"
 
 wasm-bindgen-futures = "0.4"
-futures = "0.3.14"
+futures-core = { version = "0.3", optional = true }
+futures-sink = { version = "0.3", optional = true }
 
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,24 @@ exclude = [
     ".idea",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
-default = ["json"]
+default = ["json", "websocket"]
 
 # Enables `.json()` on `Response`
 json = ["wasm-bindgen/serde-serialize", "serde", "serde_json"]
+# Enables the WebSocket API
+websocket = [
+    'web-sys/WebSocket',
+    'web-sys/ErrorEvent',
+    'web-sys/FileReader',
+    'web-sys/MessageEvent',
+    'web-sys/ProgressEvent',
+    'web-sys/CloseEvent',
+    'web-sys/BinaryType',
+]
 
 [dependencies]
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
@@ -51,15 +64,6 @@ features = [
     'ReadableStream',
     'Blob',
     'FormData',
-    'FileReader',
-    'CloseEvent',
-
-    'WebSocket',
-    'ErrorEvent',
-    'FileReader',
-    'MessageEvent',
-    'ProgressEvent',
-    'BinaryType',
 ]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ websocket = [
     'web-sys/ProgressEvent',
     'web-sys/CloseEvent',
     'web-sys/BinaryType',
+    'web-sys/Blob',
     "async-broadcast",
     "pin-project",
     "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,22 @@ exclude = [
     ".idea",
 ]
 
+[features]
+default = ["json"]
+
+# Enables `.json()` on `Response`
+json = ["wasm-bindgen/serde-serialize", "serde", "serde_json"]
+
 [dependencies]
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
 wasm-bindgen-futures = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 thiserror = "1.0"
 futures = "0.3.14"
 gloo-utils = "0.1.0"
+
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
 
 async-broadcast = "0.3"
 pin-project = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 all-features = true
 
 [features]
-default = ["json", "websocket"]
+default = ["json", "websocket", "http"]
 
 # Enables `.json()` on `Response`
 json = ["wasm-bindgen/serde-serialize", "serde", "serde_json"]
@@ -30,41 +30,44 @@ websocket = [
     'web-sys/ProgressEvent',
     'web-sys/CloseEvent',
     'web-sys/BinaryType',
+    "async-broadcast",
+    "pin-project",
+]
+# Enables the HTTP API
+http = [
+    'web-sys/Headers',
+    'web-sys/Request',
+    'web-sys/RequestInit',
+    'web-sys/RequestMode',
+    'web-sys/Response',
+    'web-sys/Window',
+    'web-sys/RequestCache',
+    'web-sys/RequestCredentials',
+    'web-sys/ObserverCallback',
+    'web-sys/RequestRedirect',
+    'web-sys/ReferrerPolicy',
+    'web-sys/AbortSignal',
+    'web-sys/ReadableStream',
+    'web-sys/Blob',
+    'web-sys/FormData',
 ]
 
 [dependencies]
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = "0.2"
+web-sys = "0.3"
 js-sys = "0.3"
-wasm-bindgen-futures = "0.4"
-thiserror = "1.0"
-futures = "0.3.14"
 gloo-utils = "0.1.0"
+
+wasm-bindgen-futures = "0.4"
+futures = "0.3.14"
+
+thiserror = "1.0"
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 
-async-broadcast = "0.3"
-pin-project = "1"
-
-[dependencies.web-sys]
-version = "0.3.4"
-features = [
-    'Headers',
-    'Request',
-    'RequestInit',
-    'RequestMode',
-    'Response',
-    'Window',
-    'RequestCache',
-    'RequestCredentials',
-    'ObserverCallback',
-    'RequestRedirect',
-    'ReferrerPolicy',
-    'AbortSignal',
-    'ReadableStream',
-    'Blob',
-    'FormData',
-]
+async-broadcast = { version = "0.3", optional = true }
+pin-project = { version = "1.0", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 use gloo_utils::errors::JsError;
 use thiserror::Error as ThisError;
-use wasm_bindgen::JsValue;
 
 /// All the errors returned by this crate.
 #[derive(Debug, ThisError)]
@@ -18,13 +17,22 @@ pub enum Error {
     ),
 }
 
-pub(crate) fn js_to_error(js_value: JsValue) -> Error {
-    Error::JsError(js_to_js_error(js_value))
-}
+#[cfg(any(feature = "http", feature = "websocket"))]
+pub(crate) use conversion::*;
+#[cfg(any(feature = "http", feature = "websocket"))]
+mod conversion {
+    use gloo_utils::errors::JsError;
+    use wasm_bindgen::JsValue;
 
-pub(crate) fn js_to_js_error(js_value: JsValue) -> JsError {
-    match JsError::try_from(js_value) {
-        Ok(error) => error,
-        Err(_) => unreachable!("JsValue passed is not an Error type -- this is a bug"),
+    #[cfg(feature = "http")]
+    pub(crate) fn js_to_error(js_value: JsValue) -> super::Error {
+        super::Error::JsError(js_to_js_error(js_value))
+    }
+
+    pub(crate) fn js_to_js_error(js_value: JsValue) -> JsError {
+        match JsError::try_from(js_value) {
+            Ok(error) => error,
+            Err(_) => unreachable!("JsValue passed is not an Error type -- this is a bug"),
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     #[error("{0}")]
     JsError(JsError),
     /// Error returned by `serde` during deserialization.
+    #[cfg(feature = "json")]
     #[error("{0}")]
     SerdeError(
         #[source]

--- a/src/http.rs
+++ b/src/http.rs
@@ -15,12 +15,15 @@
 
 use crate::{js_to_error, Error};
 use js_sys::{ArrayBuffer, Uint8Array};
-use serde::de::DeserializeOwned;
 use std::fmt;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::window;
+
+#[cfg(feature = "json")]
+use serde::de::DeserializeOwned;
+
 pub use web_sys::{
     AbortSignal, FormData, Headers, ObserverCallback, ReadableStream, ReferrerPolicy, RequestCache,
     RequestCredentials, RequestMode, RequestRedirect,
@@ -259,6 +262,7 @@ impl Response {
     }
 
     /// Gets and parses the json.
+    #[cfg(feature = "json")]
     pub async fn json<T: DeserializeOwned>(&self) -> Result<T, Error> {
         let promise = self.response.json().map_err(js_to_error)?;
         let json = JsFuture::from(promise).await.map_err(js_to_error)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 )]
 
 mod error;
+#[cfg(feature = "http")]
 pub mod http;
 #[cfg(feature = "websocket")]
 pub mod websocket;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 
 mod error;
 pub mod http;
+#[cfg(feature = "websocket")]
 pub mod websocket;
 
 pub use error::*;

--- a/src/websocket/futures.rs
+++ b/src/websocket/futures.rs
@@ -35,8 +35,8 @@ use crate::websocket::{
     Message, State, WebSocketError,
 };
 use async_broadcast::Receiver;
-use futures::ready;
-use futures::{Sink, Stream};
+use futures_core::{ready, Stream};
+use futures_sink::Sink;
 use gloo_utils::errors::JsError;
 use pin_project::{pin_project, pinned_drop};
 use std::cell::RefCell;

--- a/src/websocket/futures.rs
+++ b/src/websocket/futures.rs
@@ -11,18 +11,16 @@
 //! #    ($($expr:expr),*) => {{}};
 //! # }
 //! # fn no_run() {
-//! let mut  ws = WebSocket::open("wss://echo.websocket.org").unwrap();
+//! let mut ws = WebSocket::open("wss://echo.websocket.org").unwrap();
+//! let (mut write, mut read) = ws.split();
 //!
-//! spawn_local({
-//!     let mut  ws = ws.clone();
-//!     async move {
-//!         ws.send(Message::Text(String::from("test"))).await.unwrap();
-//!         ws.send(Message::Text(String::from("test 2"))).await.unwrap();
-//!     }
+//! spawn_local(async move {
+//!     write.send(Message::Text(String::from("test"))).await.unwrap();
+//!     write.send(Message::Text(String::from("test 2"))).await.unwrap();
 //! });
 //!
 //! spawn_local(async move {
-//!     while let Some(msg) = ws.next().await {
+//!     while let Some(msg) = read.next().await {
 //!         console_log!(format!("1. {:?}", msg))
 //!     }
 //!     console_log!("WebSocket Closed")

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1,7 +1,5 @@
-use js_sys::Uint8Array;
 use reqwasm::http::*;
 use serde::{Deserialize, Serialize};
-use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);


### PR DESCRIPTION
This PR puts the JSON support for `Response` bodies, the HTTP API and the WebSocket API behind a feature gate so user's that do not need them can disable them. By default they are still enabled as to not break compatibility, and keep it convenient. It also adds clippy checks for individual features and no features enabled to CI.

As a minor improvement, the crate no longer depends on `futures` itself, but it's individual crates that contain the parts we need: `futures-core` and `futures-sink`.