### PR TITLE
Replace `async-broadcast` with `futures-channel::mpsc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,28 @@ exclude = [
 [package.metadata.docs.rs]
 all-features = true
 
+[dependencies]
+wasm-bindgen = "0.2"
+web-sys = "0.3"
+js-sys = "0.3"
+gloo-utils = "0.1.0"
+
+wasm-bindgen-futures = "0.4"
+futures-core = { version = "0.3", optional = true }
+futures-sink = { version = "0.3", optional = true }
+
+thiserror = "1.0"
+
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
+
+futures-channel = { version = "0.3", optional = true }
+pin-project = { version = "1.0", optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+futures = "0.3"
+
 [features]
 default = ["json", "websocket", "http"]
 
@@ -31,7 +53,7 @@ websocket = [
     'web-sys/CloseEvent',
     'web-sys/BinaryType',
     'web-sys/Blob',
-    "async-broadcast",
+    "futures-channel",
     "pin-project",
     "futures-core",
     "futures-sink",
@@ -54,25 +76,3 @@ http = [
     'web-sys/Blob',
     'web-sys/FormData',
 ]
-
-[dependencies]
-wasm-bindgen = "0.2"
-web-sys = "0.3"
-js-sys = "0.3"
-gloo-utils = "0.1.0"
-
-wasm-bindgen-futures = "0.4"
-futures-core = { version = "0.3", optional = true }
-futures-sink = { version = "0.3", optional = true }
-
-thiserror = "1.0"
-
-serde = { version = "1.0", features = ["derive"], optional = true }
-serde_json = { version = "1.0", optional = true }
-
-async-broadcast = { version = "0.3", optional = true }
-pin-project = { version = "1.0", optional = true }
-
-[dev-dependencies]
-wasm-bindgen-test = "0.3"
-futures = "0.3"


### PR DESCRIPTION
We no longer need a multi-producer-multi-consumer channel. There's only one consumer as of https://github.com/hamza1311/reqwasm/commit/445e9a5bf555a0e37d0ff7fb71e69d34cb8f2493